### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: DevKit Boilerplate CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/DibyadyutiDas/devKit/security/code-scanning/1](https://github.com/DibyadyutiDas/devKit/security/code-scanning/1)

The best way to fix the issue is to add a `permissions` block at the workflow root level. This will apply minimal permissions to all jobs in the workflow unless a job explicitly overrides it. The permissions should be tailored to the workflow's requirements. In this case, the workflow only needs to read the repository contents to execute checks and compile code, so `contents: read` is sufficient.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
